### PR TITLE
Adds error handling around base 64 decoding

### DIFF
--- a/app/src/main/java/lakeeffect/ca/scoutingserverapp/Base64Encoder.java
+++ b/app/src/main/java/lakeeffect/ca/scoutingserverapp/Base64Encoder.java
@@ -1,0 +1,16 @@
+package lakeeffect.ca.scoutingserverapp;
+
+import android.util.Base64;
+
+import java.nio.charset.Charset;
+
+public class Base64Encoder {
+    public String decode(String encodedString){
+        try{
+            String returnString = new String(Base64.decode(encodedString, Base64.DEFAULT), Charset.forName("UTF-8"));
+            return returnString;
+        } catch (IllegalArgumentException e){
+            return "";
+        }
+    }
+}

--- a/app/src/main/java/lakeeffect/ca/scoutingserverapp/Base64Encoder.java
+++ b/app/src/main/java/lakeeffect/ca/scoutingserverapp/Base64Encoder.java
@@ -5,12 +5,12 @@ import android.util.Base64;
 import java.nio.charset.Charset;
 
 public class Base64Encoder {
-    public String decode(String encodedString){
+    public static String decode(String encodedString){
         try{
             String returnString = new String(Base64.decode(encodedString, Base64.DEFAULT), Charset.forName("UTF-8"));
             return returnString;
         } catch (IllegalArgumentException e){
-            return "";
+            return null;
         }
     }
 }

--- a/app/src/main/java/lakeeffect/ca/scoutingserverapp/MainActivity.java
+++ b/app/src/main/java/lakeeffect/ca/scoutingserverapp/MainActivity.java
@@ -1256,6 +1256,11 @@ public class MainActivity extends AppCompatActivity {
         try {
             data = new String(Base64.decode(data, Base64.DEFAULT), Charset.forName("UTF-8"));
         } catch (IllegalArgumentException e){
+            runOnUiThread(new Thread() {
+                public void run() {
+                    Toast.makeText(MainActivity.this, "Base 64 failed to decode", Toast.LENGTH_LONG).show();
+                }
+            });
             return;
         }
         if (data.equals("") || data.equals("\n")) {
@@ -1306,6 +1311,11 @@ public class MainActivity extends AppCompatActivity {
             try {
                 data = new String(Base64.decode(data, Base64.DEFAULT), Charset.forName("UTF-8"));
             } catch (IllegalArgumentException e){
+                runOnUiThread(new Thread() {
+                    public void run() {
+                        Toast.makeText(MainActivity.this, "Base 64 failed to decode", Toast.LENGTH_LONG).show();
+                    }
+                });
                 return;
             }
         }

--- a/app/src/main/java/lakeeffect/ca/scoutingserverapp/MainActivity.java
+++ b/app/src/main/java/lakeeffect/ca/scoutingserverapp/MainActivity.java
@@ -1253,8 +1253,11 @@ public class MainActivity extends AppCompatActivity {
         File file = new File(sdCard.getPath() + "/#ScoutingData/EventData/" + data.split(":")[0] + ".csv");
 
         data = data.replace(data.split(":")[0] + ":" + data.split(":")[1] + ":", "");
-        data = new String(Base64.decode(data, Base64.DEFAULT), Charset.forName("UTF-8"));
-
+        try {
+            data = new String(Base64.decode(data, Base64.DEFAULT), Charset.forName("UTF-8"));
+        } catch (IllegalArgumentException e){
+            return;
+        }
         if (data.equals("") || data.equals("\n")) {
             return;
         }
@@ -1300,7 +1303,11 @@ public class MainActivity extends AppCompatActivity {
             data = data.replace(":" + data.split(":")[1], "");
 
             //decode data from base 64
-            data = new String(Base64.decode(data, Base64.DEFAULT), Charset.forName("UTF-8"));
+            try {
+                data = new String(Base64.decode(data, Base64.DEFAULT), Charset.forName("UTF-8"));
+            } catch (IllegalArgumentException e){
+                return;
+            }
         }
 
         System.out.println(data);

--- a/app/src/main/java/lakeeffect/ca/scoutingserverapp/PullDataThread.java
+++ b/app/src/main/java/lakeeffect/ca/scoutingserverapp/PullDataThread.java
@@ -87,6 +87,16 @@ public class PullDataThread extends Thread{
                 if(version >= mainActivity.minVersionNum){
                     String labels = fullLabelsMessage.split(":::")[1];
                     String decodedLabels = Base64Encoder.decode(labels);
+
+                    if (decodedLabels == null) {
+                        decodedLabels = "Failed to decode labels from " + device.getName() + ". Base 64: '" + labels + "'";;
+                        mainActivity.runOnUiThread(new Thread() {
+                            public void run() {
+                                Toast.makeText(mainActivity, "Failed to decode labels from " + device.getName(), Toast.LENGTH_LONG).show();
+                            }
+                        });
+                    }
+
                     mainActivity.labels = decodedLabels;
                 }else{
                     //send toast saying that the client has a version too old
@@ -205,6 +215,16 @@ public class PullDataThread extends Thread{
                     for(int i = 0; i < data.length; i++){
                         String matchData = data[i];
                         String decodedMatchData = Base64Encoder.decode(matchData);
+
+                        if (decodedMatchData == null) {
+                            decodedMatchData = "Failed to decode match data from " + device.getName() + ". Base 64: '" + matchData + "'";
+                            mainActivity.runOnUiThread(new Thread() {
+                                public void run() {
+                                    Toast.makeText(mainActivity, "Failed to decode match data from " + device.getName(), Toast.LENGTH_LONG).show();
+                                }
+                            });
+                        }
+
                         if(mainActivity.stringListContains(mainActivity.uuids, mainActivity.getUUIDFromData(decodedMatchData))){
                             //send toast saying that the data already exists
                             mainActivity.runOnUiThread(new Thread(){
@@ -302,6 +322,15 @@ public class PullDataThread extends Thread{
 
             //convert message out of base 64
             String decodedMessage = Base64Encoder.decode(message);
+
+            if (decodedMessage == null) {
+                decodedMessage = "Failed to decode message from " + device.getName() + ". Base 64: '" + message + "'";;
+                mainActivity.runOnUiThread(new Thread() {
+                    public void run() {
+                        Toast.makeText(mainActivity, "Failed to decode message from " + device.getName(), Toast.LENGTH_LONG).show();
+                    }
+                });
+            }
 
             return decodedMessage;
         }

--- a/app/src/main/java/lakeeffect/ca/scoutingserverapp/PullDataThread.java
+++ b/app/src/main/java/lakeeffect/ca/scoutingserverapp/PullDataThread.java
@@ -86,7 +86,7 @@ public class PullDataThread extends Thread{
                 int version = Integer.parseInt(fullLabelsMessage.split(":::")[0]);
                 if(version >= mainActivity.minVersionNum){
                     String labels = fullLabelsMessage.split(":::")[1];
-                    String decodedLabels = new String(Base64.decode(labels, Base64.DEFAULT), Charset.forName("UTF-8"));
+                    String decodedLabels = Base64Encoder.decode(labels);
                     mainActivity.labels = decodedLabels;
                 }else{
                     //send toast saying that the client has a version too old
@@ -204,8 +204,7 @@ public class PullDataThread extends Thread{
                 }else{
                     for(int i = 0; i < data.length; i++){
                         String matchData = data[i];
-                        String decodedMatchData = new String(Base64.decode(matchData, Base64.DEFAULT), Charset.forName("UTF-8"));
-
+                        String decodedMatchData = Base64Encoder.decode(matchData);
                         if(mainActivity.stringListContains(mainActivity.uuids, mainActivity.getUUIDFromData(decodedMatchData))){
                             //send toast saying that the data already exists
                             mainActivity.runOnUiThread(new Thread(){
@@ -302,7 +301,7 @@ public class PullDataThread extends Thread{
             message = message.substring(0, message.length() - endSplitter.length());
 
             //convert message out of base 64
-            String decodedMessage = new String(Base64.decode(message, Base64.DEFAULT), Charset.forName("UTF-8"));
+            String decodedMessage = Base64Encoder.decode(message);
 
             return decodedMessage;
         }


### PR DESCRIPTION
This will cause functions to either terminate early, as in saveEvents() and save(), or return an empty string, as in PullDataThread.run(), or .waitForMessage(), as opposed to crashing.